### PR TITLE
Remove typo for pool => poll keyword

### DIFF
--- a/lib/event_store_client/client.rb
+++ b/lib/event_store_client/client.rb
@@ -17,10 +17,10 @@ module EventStoreClient
     def subscribe(subscriber, to: [], polling: true)
       raise NoCallMethodOnSubscriber unless subscriber.respond_to?(:call)
       @subscriptions.create(subscriber, to)
-      pool if polling
+      poll if polling
     end
 
-    def pool(interval: 5)
+    def poll(interval: 5)
       return if @polling_started
       @polling_started = true
       thread1 = Thread.new do

--- a/lib/event_store_client/configuration.rb
+++ b/lib/event_store_client/configuration.rb
@@ -19,7 +19,7 @@ module EventStoreClient
       @host = 'http://localhost'
       @port = 2113
       @per_page = 20
-      @pid_path = 'tmp/pool.pid'
+      @pid_path = 'tmp/poll.pid'
       @mapper = Mapper::Default.new
       @service_name = 'default'
       @error_handler = nil

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -52,9 +52,9 @@ module EventStoreClient
           stream_name,
           subscription_name,
           count: 1,
-          long_pool: 0
+          long_poll: 0
         )
-          headers = long_pool.positive? ? { 'ES-LongPoll' => long_pool.to_s } : {}
+          headers = long_poll.positive? ? { 'ES-LongPoll' => long_poll.to_s } : {}
           headers['Content-Type'] = 'application/vnd.eventstore.competingatom+json'
           headers['Accept'] = 'application/vnd.eventstore.competingatom+json'
           make_request(

--- a/spec/event_store_client/client_spec.rb
+++ b/spec/event_store_client/client_spec.rb
@@ -27,7 +27,7 @@ module EventStoreClient
     describe 'subscribe' do
     end
 
-    describe 'pool' do
+    describe 'poll' do
     end
 
     describe '#stop_polling' do


### PR DESCRIPTION
The typo included the `pool` word, not only the `pooling`