### PR TITLE
Fix bugs for deserialized_events

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,20 @@ Before you start, add this to the `initializer` or to the top of your script:
 To test out the behavior, you'll need a sample event and handler to work with:
 
 ```ruby
-# Sample Event using dry-struct (recommended)
-require 'dry-struct'
-class SomethingHappened < Dry::Struct
-  attribute :data, EventStoreClient::Types::Strict::Hash
-  attribute :metadata, EventStoreClient::Types::Strict::Hash
-end
 
-# Sample Event without types check (not recommended)
+require 'securerandom'
 
-class SomethingHappened < Dry::Struct
-  attr_reader :data, :metadata
-
-  private
-
-  def initialize(data: {}, metadata: {})
-    @data = data
-    @metadata = metadata
+class SomethingHappened < EventStoreClient::DeserializedEvent
+  def schema
+    Dry::Schema.Params do
+      required(:user_id).value(:string)
+      required(:email).value(:string)
+    end
   end
 end
 
 event = SomethingHappened.new(
   data: { user_id: SecureRandom.uuid, title: "Something happened" },
-  metadata: {}
 )
 ```
 

--- a/lib/event_store_client/deserialized_event.rb
+++ b/lib/event_store_client/deserialized_event.rb
@@ -1,13 +1,28 @@
 # frozen_string_literal: true
 
 require 'dry-struct'
-require 'securerandom'
-require 'json'
+require 'dry/schema'
 
 module EventStoreClient
-  class DeserializedEvent < Dry::Struct
-    attribute :data, Types::Strict::Hash.default({}.freeze)
-    attribute :metadata, Types::Strict::Hash.default({}.freeze)
-    attribute :type, Types::Strict::String
+  class DeserializedEvent
+    InvalidDataError = Class.new(StandardError)
+
+    attr_reader :data
+    attr_reader :metadata
+    attr_reader :type
+
+    def schema
+      Dry::Schema.Params do
+      end
+    end
+
+    def initialize(**args)
+      validation = schema.call(args[:data] || {})
+      raise InvalidDataError.new(message: validation.errors.to_h) if validation.errors.any?
+
+      @data = args.fetch(:data) { {} }
+      @metadata = args.fetch(:metadata) { {} }
+      @type = args[:type] || self.class.name
+    end
   end
 end

--- a/lib/event_store_client/mapper/default.rb
+++ b/lib/event_store_client/mapper/default.rb
@@ -15,19 +15,18 @@ module EventStoreClient
         metadata = serializer.deserialize(event.metadata)
         data = serializer.deserialize(event.data)
 
-        event_class = event.type.safe_constantize
-        if event_class
-          event_class.new(
-            metadata: metadata,
-            data: data
-          )
-        else
-          EventStoreClient::DeserializedEvent.new(
-            metadata: metadata,
-            data: data,
-            type: event.type
-          )
-        end
+        event_class =
+          begin
+            Object.const_get(event.type)
+          rescue NameError
+            EventStoreClient::DeserializedEvent
+          end
+
+        event_class.new(
+          metadata: metadata,
+          data: data,
+          type: event.type
+        )
       end
 
       private

--- a/spec/event_store_client/mapper/default_spec.rb
+++ b/spec/event_store_client/mapper/default_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module EventStoreClient
+  RSpec.describe Mapper::Default do
+    let(:data) do
+      {
+        'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+        'email' => 'darth@vader.sv'
+      }
+    end
+
+    describe '#serialize' do
+      let(:user_registered) { UserRegistered.new(data: data) }
+
+      subject { described_class.new.serialize(user_registered) }
+
+      it 'returns serialized event' do
+        expect(subject).to be_kind_of(EventStoreClient::Event)
+        expect(subject.data).to eq(JSON.generate(data))
+        expect(subject.metadata).to include('created_at')
+        expect(subject.type).to eq('UserRegistered')
+      end
+    end
+
+    describe '#deserialize' do
+      context 'when the event type const exists' do
+        let(:event) { SerializedEvent.new(type: 'UserRegistered') }
+        subject { described_class.new.deserialize(event) }
+
+        it 'returns instance of UserRegistered' do
+          expect(subject).to be_kind_of(UserRegistered)
+          expect(subject.data).to eq(data)
+          expect(subject.metadata['created_at']).not_to be_nil
+          expect(subject.type).to eq('UserRegistered')
+        end
+      end
+
+      context 'when the event type const does not exist' do
+        let(:event) { SerializedEvent.new(type: 'SomethingHappened') }
+
+        subject { described_class.new.deserialize(event) }
+
+        it 'returns instance of DeserializedEvent' do
+          expect(subject).to be_kind_of(DeserializedEvent)
+          expect(subject.data).to eq(data)
+          expect(subject.metadata['created_at']).not_to be_nil
+          expect(subject.type).to eq('SomethingHappened')
+        end
+      end
+    end
+  end
+end
+
+class DummyRepository
+  def encrypt(*)
+    'encrypted'
+  end
+end
+
+class UserRegistered < EventStoreClient::DeserializedEvent
+  def schema
+    Dry::Schema.Params do
+      required(:user_id).value(:string)
+      required(:email).value(:string)
+    end
+  end
+end
+
+class SerializedEvent
+  attr_reader :type
+
+  def metadata
+    '{"created_at":"2019-12-05 19:37:38 +0100"}'
+  end
+
+  def data
+    '{"user_id":"dab48d26-e4f8-41fc-a9a8-59657e590716","email":"darth@vader.sv"}'
+  end
+
+  private
+
+  def initialize(type:)
+    @type = type
+  end
+end


### PR DESCRIPTION
1. Added test coverage for default mappers, which detected few problems
2. Fixed `safe_constantize` method call which is a Rails method.
3. Removed unnecessary `require` calls
4. Improved the DeserializedEvent definition.