### PR TITLE
Add encrypted mapper to hide vulnerable data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,99 @@ client.link_to(stream: 'anotherstream', events: [exisiting_event1, ...])
 When you read from stream where links are placed. By default Event Store Client always resolve links for you returning the event that points to the link. You can use the ES-ResolveLinkTos: false HTTP header during readin stream to tell Event Store Client to return you the actual link and to not resolve it.
 More info: [ES-ResolveLinkTos](https://eventstore.org/docs/http-api/optional-http-headers/resolve-linkto/index.html?tabs=tabid-1%2Ctabid-3).
 
+## Event Mappers
+
+We offer two types of mappers - default and encrypted.
+
+### Default Mapper
+
+This is used out of the box. It just translates the EventClass defined in your application to
+Event parsable by event_store and the other way around.
+
+### Encrypted Mapper
+
+This is implemented to match GDPR requirements. It allows you to encrypt any event using your
+encryption_key repository.
+
+```ruby
+mapper = EventStoreClient::Mapper::Encrypted.new(key_repository)
+EventStoreClient.configure do |config|
+  config.mapper = mapper
+end
+```
+
+The Encrypted mapper uses the encryption key repository to encrypt data in your events according to the event definition.
+
+Here is the minimal repository interface for this to work.
+
+```ruby
+class DummyRepository
+  class Key
+    attr_accessor :iv, :cipher, :id
+    def initialize(id:, **)
+      @id = id
+    end
+  end
+
+  def find(user_id)
+    Key.new(id: user_id)
+  end
+
+  def encrypt(*)
+    'darthvader'
+  end
+
+  def decrypt(*)
+    { first_name: 'Anakin', last_name: 'Skylwalker'}
+  end
+end
+```
+
+Now, having that, you only need to define the event encryption schema:
+
+```ruby
+class EncryptedEvent < EventStoreClient::DeserializedEvent
+  def schema
+    Dry::Schema.Params do
+      required(:user_id).value(:string)
+      required(:first_name).value(:string)
+      required(:last_name).value(:string)
+      required(:profession).value(:string)
+    end
+  end
+
+  def self.encryption_schema
+    {
+      key: ->(data) { data['user_id'] },
+      attributes: %i[first_name last_name email]
+    }
+  end
+end
+
+event = EncryptedEvent.new(
+  user_id: SecureRandom.uuid,
+  first_name: 'Anakin',
+  last_name: 'Skylwalker',
+  profession: 'Jedi'
+)
+```
+
+When you'll publish this event, in the store will be saved:
+
+```ruby
+{
+  'data' => {
+    'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+    'first_name' => 'encrypted',
+    'last_name' => 'encrypted',
+    'profession' => 'Jedi',
+    'encrypted' => '2345l423lj1#$!lkj24f1'
+  },
+  type: 'EncryptedEvent'
+  metadata: { ... }
+}
+```
+
 ## Contributing
 
 Do you want to contribute? Welcome!

--- a/lib/event_store_client/data_encryptor.rb
+++ b/lib/event_store_client/data_encryptor.rb
@@ -32,7 +32,7 @@ module EventStoreClient
       encrypted = key_repository.encrypt(
         key_id: key.id, text: text, cipher: key.cipher, iv: key.iv
       )
-      attributes.each { |att| data[att] = 'es_encrypted' }
+      attributes.each { |att| data[att] = 'es_encrypted' if data.key?(att) }
       data[:es_encrypted] = encrypted
       data
     end

--- a/lib/event_store_client/data_encryptor.rb
+++ b/lib/event_store_client/data_encryptor.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module EventStoreClient
+  class DataEncryptor
+    def call
+      return encrypted_data unless encryption_metadata
+      encryption_metadata.each do |key_id, val|
+        key = key_repository.find(key_id) || key_repository.create(key_id)
+        val[:iv] ||= key.iv
+        val[:attributes].each do |att|
+          encrypted_data[att] = encrypt_attribute(
+            key, encrypted_data.fetch(att)
+          )
+        end
+      end
+      encrypted_data
+    end
+
+    attr_reader :encrypted_data, :encryption_metadata
+
+    private
+
+    attr_reader :key_repository
+
+    def initialize(data:, schema:, repository:)
+      @encrypted_data = deep_dup(data)
+      @key_repository = repository
+      @encryption_metadata = EncryptionMetadata.new(data: data, schema: schema).call
+    end
+
+    def encrypt_attribute(key, text)
+      key_repository.encrypt(
+        key_id: key.id, text: text, cipher: key.cipher, iv: key.iv
+      )
+    end
+
+    def deep_dup(hash)
+      dupl = hash.dup
+      dupl.each { |k, v| dupl[k] = v.instance_of?(Hash) ? deep_dup(v) : v }
+      dupl
+    end
+  end
+end

--- a/lib/event_store_client/data_encryptor.rb
+++ b/lib/event_store_client/data_encryptor.rb
@@ -32,8 +32,8 @@ module EventStoreClient
       encrypted = key_repository.encrypt(
         key_id: key.id, text: text, cipher: key.cipher, iv: key.iv
       )
-      attributes.each { |att| data[att] = 'encrypted' }
-      data[:encrypted] = encrypted
+      attributes.each { |att| data[att] = 'es_encrypted' }
+      data[:es_encrypted] = encrypted
       data
     end
 

--- a/lib/event_store_client/encryption_metadata.rb
+++ b/lib/event_store_client/encryption_metadata.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+
+module EventStoreClient
+  class EncryptionMetadata
+    def call
+      return {} unless schema
+
+      schema.each_with_object({}) do |(attr_name, key_proc), acc|
+        key_identifier = key_proc.call(data)
+        acc[key_identifier] ||= { attributes: [] }
+        acc[key_identifier][:attributes] |= [attr_name]
+        acc
+      end
+    end
+
+    private
+
+    attr_reader :data, :schema
+
+    def initialize(data:, schema:)
+      @data = data
+      @schema = schema
+    end
+  end
+end

--- a/lib/event_store_client/encryption_metadata.rb
+++ b/lib/event_store_client/encryption_metadata.rb
@@ -6,12 +6,10 @@ module EventStoreClient
     def call
       return {} unless schema
 
-      schema.each_with_object({}) do |(attr_name, key_proc), acc|
-        key_identifier = key_proc.call(data)
-        acc[key_identifier] ||= { attributes: [] }
-        acc[key_identifier][:attributes] |= [attr_name]
-        acc
-      end
+      {
+        key: schema[:key].call(data),
+        attributes: schema[:attributes].map(&:to_sym)
+      }
     end
 
     private

--- a/lib/event_store_client/mapper.rb
+++ b/lib/event_store_client/mapper.rb
@@ -6,3 +6,4 @@ module EventStoreClient
 end
 
 require 'event_store_client/mapper/default'
+require 'event_store_client/mapper/encrypted'

--- a/lib/event_store_client/mapper/encrypted.rb
+++ b/lib/event_store_client/mapper/encrypted.rb
@@ -59,8 +59,8 @@ module EventStoreClient
       # * +key_repoistory+ - repository stored encryption keys. Passed down to the +DataEncryptor+
       # * +serializer+ - object used to serialize data. By default JSON serializer is used.
       def initialize(key_repository, serializer: Serializer::Json)
-        @key_repository         = key_repository
-        @serializer             = serializer
+        @key_repository = key_repository
+        @serializer = serializer
       end
     end
   end

--- a/lib/event_store_client/mapper/encrypted.rb
+++ b/lib/event_store_client/mapper/encrypted.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'event_store_client/encryption_metadata'
+require 'event_store_client/data_encryptor'
+
+module EventStoreClient
+  module Mapper
+    class Encrypted
+      MissingEncryptionKey = Class.new(StandardError)
+
+      def serialize(event)
+        encryption_schema = (
+          event.class.respond_to?(:encryption_schema) &&
+          event.class.encryption_schema
+        )
+        encryptor = DataEncryptor.new(
+          data: event.data,
+          schema: encryption_schema,
+          repository: key_repository
+        )
+        encryptor.call
+        Event.new(
+          data: serializer.serialize(encryptor.encrypted_data),
+          metadata: serializer.serialize(
+            event.metadata.merge(encryption: encryptor.encryption_metadata)
+          ),
+          type: event.class.to_s
+        )
+      end
+
+      def deserialize(event)
+        # todo
+      end
+
+      private
+
+      attr_reader :key_repository, :serializer
+
+      def initialize(key_repository, serializer: Serializer::Json)
+        @key_repository         = key_repository
+        @serializer             = serializer
+      end
+    end
+  end
+end

--- a/lib/event_store_client/mapper/encrypted.rb
+++ b/lib/event_store_client/mapper/encrypted.rb
@@ -28,9 +28,7 @@ module EventStoreClient
         )
       end
 
-      def deserialize(event)
-        # todo
-      end
+      def deserialize(_event); end
 
       private
 

--- a/lib/event_store_client/mapper/encrypted.rb
+++ b/lib/event_store_client/mapper/encrypted.rb
@@ -5,8 +5,20 @@ require 'event_store_client/data_encryptor'
 
 module EventStoreClient
   module Mapper
+    ##
+    # Transforms given event's data and encrypts/decrypts selected subset of data
+    # based on encryption schema stored in the event itself.
+
     class Encrypted
       MissingEncryptionKey = Class.new(StandardError)
+
+      ##
+      # Encrypts the given event's subset of data.
+      # Accepts specific event class instance with:
+      # * +#data+ - hash with non-encrypted values.
+      # * encryption_schema - hash with information which data to encrypt and
+      #   which key should be used as an identifier.
+      # *Returns*: General +Event+ instance with encrypted data
 
       def serialize(event)
         encryption_schema = (
@@ -28,12 +40,24 @@ module EventStoreClient
         )
       end
 
+      ##
+      # Decrypts the given event's subset of data.
+      # General +Event+ instance with encrypted data
+      # * +#data+ - hash with encrypted values.
+      # * encryption_metadata - hash with information which data to encrypt and
+      #   which key should be used as an identifier.
+      # *Returns*: Specific event class with all data decrypted
+
       def deserialize(_event); end
 
       private
 
       attr_reader :key_repository, :serializer
 
+      ##
+      # Initializes the mapper with required dependencies. Accepts:
+      # * +key_repoistory+ - repository stored encryption keys. Passed down to the +DataEncryptor+
+      # * +serializer+ - object used to serialize data. By default JSON serializer is used.
       def initialize(key_repository, serializer: Serializer::Json)
         @key_repository         = key_repository
         @serializer             = serializer

--- a/spec/event_store_client/data_encryptor_spec.rb
+++ b/spec/event_store_client/data_encryptor_spec.rb
@@ -30,6 +30,18 @@ module EventStoreClient
           es_encrypted: 'darthvader'
         )
       end
+
+      it 'skips the encryption of non-existing keys' do
+        schema[:attributes] << :side
+        subject.call
+        expect(subject.encrypted_data).to eq(
+          user_id: user_id,
+          first_name: 'es_encrypted',
+          last_name: 'es_encrypted',
+          profession: 'Jedi',
+          es_encrypted: 'darthvader'
+        )
+      end
     end
 
     let(:key_repository) { DummyRepository.new }

--- a/spec/event_store_client/data_encryptor_spec.rb
+++ b/spec/event_store_client/data_encryptor_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module EventStoreClient
+  RSpec.describe DataEncryptor do
+    let(:key_repository) { DummyRepository.new }
+    let(:user_id) { SecureRandom.uuid }
+    let(:data) do
+      {
+        user_id: user_id,
+        email: 'darth@vader.sv',
+        encrypted: 'Foo',
+        not_encrypted: 'Bar'
+      }
+    end
+
+    let(:schema) do
+      {
+        email: ->(data) { data[:user_id] },
+        encrypted: ->(data) { data[:user_id] }
+      }
+    end
+
+    describe '#call' do
+      let(:repository) { DummyRepository.new }
+
+      subject { described_class.new(data: data, schema: schema, repository: repository).call }
+
+      it 'returns encrypted data' do
+        expect(subject).to eq(
+          user_id: user_id,
+          email: 'encrypted',
+          encrypted: 'encrypted',
+          not_encrypted: 'Bar'
+        )
+      end
+    end
+  end
+end
+
+class DummyRepository
+  class Key
+    attr_accessor :iv, :cipher, :id
+    def initialize(id:, **)
+      @id = id
+    end
+  end
+
+  def find(user_id)
+    Key.new(id: user_id)
+  end
+
+  def encrypt(*)
+    'encrypted'
+  end
+
+  def decrypt(*)
+    'decrypted'
+  end
+end

--- a/spec/event_store_client/data_encryptor_spec.rb
+++ b/spec/event_store_client/data_encryptor_spec.rb
@@ -4,37 +4,49 @@ require 'securerandom'
 
 module EventStoreClient
   RSpec.describe DataEncryptor do
+    describe '#call' do
+      let(:repository) { DummyRepository.new }
+
+      subject { described_class.new(data: data, schema: schema, repository: repository) }
+
+      it 'returns encrypted data' do
+        expect(subject.call).to eq(
+          user_id: user_id,
+          first_name: 'encrypted',
+          last_name: 'encrypted',
+          profession: 'Jedi',
+          encrypted: 'darthvader'
+        )
+      end
+
+      it 'updates the encrypted data reader' do
+        subject.call
+        expect(subject.encrypted_data).to eq(
+          user_id: user_id,
+          first_name: 'encrypted',
+          last_name: 'encrypted',
+          profession: 'Jedi',
+          encrypted: 'darthvader'
+        )
+      end
+    end
+
     let(:key_repository) { DummyRepository.new }
     let(:user_id) { SecureRandom.uuid }
     let(:data) do
       {
         user_id: user_id,
-        email: 'darth@vader.sv',
-        encrypted: 'Foo',
-        not_encrypted: 'Bar'
+        first_name: 'Anakin',
+        last_name: 'Skylwalker',
+        profession: 'Jedi'
       }
     end
 
     let(:schema) do
       {
-        email: ->(data) { data[:user_id] },
-        encrypted: ->(data) { data[:user_id] }
+        key: ->(data) { data[:user_id] },
+        attributes: %i[first_name last_name]
       }
-    end
-
-    describe '#call' do
-      let(:repository) { DummyRepository.new }
-
-      subject { described_class.new(data: data, schema: schema, repository: repository).call }
-
-      it 'returns encrypted data' do
-        expect(subject).to eq(
-          user_id: user_id,
-          email: 'encrypted',
-          encrypted: 'encrypted',
-          not_encrypted: 'Bar'
-        )
-      end
     end
   end
 end
@@ -52,10 +64,10 @@ class DummyRepository
   end
 
   def encrypt(*)
-    'encrypted'
+    'darthvader'
   end
 
   def decrypt(*)
-    'decrypted'
+    JSON.gnereate(first_name: 'Anakin', last_name: 'Skylwalker')
   end
 end

--- a/spec/event_store_client/data_encryptor_spec.rb
+++ b/spec/event_store_client/data_encryptor_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'securerandom'
+require 'support/dummy_repository'
 
 module EventStoreClient
   RSpec.describe DataEncryptor do
@@ -48,26 +49,5 @@ module EventStoreClient
         attributes: %i[first_name last_name]
       }
     end
-  end
-end
-
-class DummyRepository
-  class Key
-    attr_accessor :iv, :cipher, :id
-    def initialize(id:, **)
-      @id = id
-    end
-  end
-
-  def find(user_id)
-    Key.new(id: user_id)
-  end
-
-  def encrypt(*)
-    'darthvader'
-  end
-
-  def decrypt(*)
-    JSON.gnereate(first_name: 'Anakin', last_name: 'Skylwalker')
   end
 end

--- a/spec/event_store_client/data_encryptor_spec.rb
+++ b/spec/event_store_client/data_encryptor_spec.rb
@@ -13,10 +13,10 @@ module EventStoreClient
       it 'returns encrypted data' do
         expect(subject.call).to eq(
           user_id: user_id,
-          first_name: 'encrypted',
-          last_name: 'encrypted',
+          first_name: 'es_encrypted',
+          last_name: 'es_encrypted',
           profession: 'Jedi',
-          encrypted: 'darthvader'
+          es_encrypted: 'darthvader'
         )
       end
 
@@ -24,10 +24,10 @@ module EventStoreClient
         subject.call
         expect(subject.encrypted_data).to eq(
           user_id: user_id,
-          first_name: 'encrypted',
-          last_name: 'encrypted',
+          first_name: 'es_encrypted',
+          last_name: 'es_encrypted',
           profession: 'Jedi',
-          encrypted: 'darthvader'
+          es_encrypted: 'darthvader'
         )
       end
     end

--- a/spec/event_store_client/encryption_metadata_spec.rb
+++ b/spec/event_store_client/encryption_metadata_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module EventStoreClient
+  RSpec.describe EncryptionMetadata do
+    let(:user_id) { SecureRandom.uuid }
+    let(:data) do
+      {
+        user_id: user_id,
+        email: 'darth@vader.sv',
+        encrypted: 'Foo',
+        not_encrypted: 'Bar'
+      }
+    end
+
+    let(:schema) do
+      {
+        email: ->(data) { data[:user_id] },
+        encrypted: ->(data) { data[:user_id] }
+      }
+    end
+
+    let(:metadata) { described_class.new(data: data, schema: schema) }
+
+    describe '#call' do
+      subject { metadata.call }
+
+      it 'returns transformed object' do
+        expect(subject).to eq(
+          user_id => { attributes: %i[email encrypted] }
+        )
+      end
+    end
+  end
+end

--- a/spec/event_store_client/encryption_metadata_spec.rb
+++ b/spec/event_store_client/encryption_metadata_spec.rb
@@ -8,16 +8,16 @@ module EventStoreClient
     let(:data) do
       {
         user_id: user_id,
-        email: 'darth@vader.sv',
-        encrypted: 'Foo',
-        not_encrypted: 'Bar'
+        first_name: 'Anakin',
+        last_name: 'Skylwalker',
+        profession: 'Jedi'
       }
     end
 
     let(:schema) do
       {
-        email: ->(data) { data[:user_id] },
-        encrypted: ->(data) { data[:user_id] }
+        key: ->(data) { data[:user_id] },
+        attributes: %i[first_name last_name]
       }
     end
 
@@ -28,7 +28,8 @@ module EventStoreClient
 
       it 'returns transformed object' do
         expect(subject).to eq(
-          user_id => { attributes: %i[email encrypted] }
+          key: user_id,
+          attributes: %i[first_name last_name]
         )
       end
     end

--- a/spec/event_store_client/mapper/encrypted_spec.rb
+++ b/spec/event_store_client/mapper/encrypted_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'support/dummy_repository'
+
 module EventStoreClient
   RSpec.describe Mapper::Encrypted do
     let(:data) do
@@ -38,27 +40,6 @@ module EventStoreClient
     describe '#deserialize' do
       # TODO
     end
-  end
-end
-
-class DummyRepository
-  class Key
-    attr_accessor :iv, :cipher, :id
-    def initialize(id:, **)
-      @id = id
-    end
-  end
-
-  def find(user_id)
-    Key.new(id: user_id)
-  end
-
-  def encrypt(*)
-    'darthvader'
-  end
-
-  def decrypt(*)
-    JSON.generate(first_name: 'Anakin', last_name: 'Skylwalker')
   end
 end
 

--- a/spec/event_store_client/mapper/encrypted_spec.rb
+++ b/spec/event_store_client/mapper/encrypted_spec.rb
@@ -18,10 +18,10 @@ module EventStoreClient
       let(:encrypted_data) do
         {
           'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
-          'first_name' => 'encrypted',
-          'last_name' => 'encrypted',
+          'first_name' => 'es_encrypted',
+          'last_name' => 'es_encrypted',
           'profession' => 'Jedi',
-          'encrypted' => 'darthvader'
+          'es_encrypted' => 'darthvader'
         }
       end
 

--- a/spec/event_store_client/mapper/encrypted_spec.rb
+++ b/spec/event_store_client/mapper/encrypted_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module EventStoreClient
+  RSpec.describe Mapper::Encrypted do
+    let(:data) do
+      {
+        'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+        'email' => 'darth@vader.sv',
+        'first_name' => 'Anakin',
+        'last_name' => 'Skylwalker'
+      }
+    end
+
+    describe '#serialize' do
+      let(:encrypted_data) do
+        {
+          'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+          'email' => 'encrypted',
+          'first_name' => 'encrypted',
+          'last_name' => 'Skylwalker'
+        }
+      end
+
+      let(:user_registered) { EncryptedEvent.new(data: data) }
+
+      subject { described_class.new(DummyRepository.new).serialize(user_registered) }
+
+      it 'returns serialized event' do
+        expect(subject).to be_kind_of(EventStoreClient::Event)
+        expect(subject.data).to eq(JSON.generate(encrypted_data))
+        expect(subject.metadata).to include('created_at')
+        expect(subject.metadata).to include('encryption')
+        expect(subject.type).to eq('EncryptedEvent')
+      end
+    end
+
+    describe '#deserialize' do
+      # TODO
+    end
+  end
+end
+
+class DummyRepository
+  class Key
+    attr_accessor :iv, :cipher, :id
+    def initialize(id:, **)
+      @id = id
+    end
+  end
+
+  def find(user_id)
+    Key.new(id: user_id)
+  end
+
+  def encrypt(*)
+    'encrypted'
+  end
+
+  def decrypt(*)
+    'decrypted'
+  end
+end
+
+class EncryptedEvent < EventStoreClient::DeserializedEvent
+  def schema
+    Dry::Schema.Params do
+      required(:user_id).value(:string)
+      required(:email).value(:string)
+      required(:first_name).value(:string)
+      required(:last_name).value(:string)
+    end
+  end
+
+  def self.encryption_schema
+    {
+      'email' => ->(data) { data['user_id'] },
+      'first_name' => ->(data) { data['user_id'] }
+    }
+  end
+end
+
+class SerializedEncryptedEvent
+  attr_reader :type
+
+  def metadata
+    '{"created_at":"2019-12-05 19:37:38 +0100"}'
+  end
+
+  def data
+    '{"user_id":"dab48d26-e4f8-41fc-a9a8-59657e590716","email":"encrypted","first_name":"encrypted"}' # rubocop:disable Metrics/LineLength
+  end
+
+  private
+
+  def initialize(type:)
+    @type = type
+  end
+end

--- a/spec/event_store_client/mapper/encrypted_spec.rb
+++ b/spec/event_store_client/mapper/encrypted_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'support/encrypted_event'
 require 'support/dummy_repository'
 
 module EventStoreClient
@@ -40,47 +41,5 @@ module EventStoreClient
     describe '#deserialize' do
       # TODO
     end
-  end
-end
-
-class EncryptedEvent < EventStoreClient::DeserializedEvent
-  def schema
-    Dry::Schema.Params do
-      required(:user_id).value(:string)
-      required(:first_name).value(:string)
-      required(:last_name).value(:string)
-      required(:profession).value(:string)
-    end
-  end
-
-  def self.encryption_schema
-    {
-      key: ->(data) { data[:user_id] },
-      attributes: %i[first_name last_name]
-    }
-  end
-end
-
-class SerializedEncryptedEvent
-  attr_reader :type
-
-  def metadata
-    '{"created_at":"2019-12-05 19:37:38 +0100"}'
-  end
-
-  def data
-    JSON.generate(
-      user_id: 'dab48d26-e4f8-41fc-a9a8-59657e590716',
-      first_name: 'encrypted',
-      last_name: 'encrypted',
-      profession: 'Jedi',
-      encrypted: 'darthvader'
-    )
-  end
-
-  private
-
-  def initialize(type:)
-    @type = type
   end
 end

--- a/spec/event_store_client/mapper/encrypted_spec.rb
+++ b/spec/event_store_client/mapper/encrypted_spec.rb
@@ -5,9 +5,9 @@ module EventStoreClient
     let(:data) do
       {
         'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
-        'email' => 'darth@vader.sv',
         'first_name' => 'Anakin',
-        'last_name' => 'Skylwalker'
+        'last_name' => 'Skylwalker',
+        'profession' => 'Jedi'
       }
     end
 
@@ -15,9 +15,10 @@ module EventStoreClient
       let(:encrypted_data) do
         {
           'user_id' => 'dab48d26-e4f8-41fc-a9a8-59657e590716',
-          'email' => 'encrypted',
           'first_name' => 'encrypted',
-          'last_name' => 'Skylwalker'
+          'last_name' => 'encrypted',
+          'profession' => 'Jedi',
+          'encrypted' => 'darthvader'
         }
       end
 
@@ -53,11 +54,11 @@ class DummyRepository
   end
 
   def encrypt(*)
-    'encrypted'
+    'darthvader'
   end
 
   def decrypt(*)
-    'decrypted'
+    JSON.generate(first_name: 'Anakin', last_name: 'Skylwalker')
   end
 end
 
@@ -65,16 +66,16 @@ class EncryptedEvent < EventStoreClient::DeserializedEvent
   def schema
     Dry::Schema.Params do
       required(:user_id).value(:string)
-      required(:email).value(:string)
       required(:first_name).value(:string)
       required(:last_name).value(:string)
+      required(:profession).value(:string)
     end
   end
 
   def self.encryption_schema
     {
-      'email' => ->(data) { data['user_id'] },
-      'first_name' => ->(data) { data['user_id'] }
+      key: ->(data) { data[:user_id] },
+      attributes: %i[first_name last_name]
     }
   end
 end
@@ -87,7 +88,13 @@ class SerializedEncryptedEvent
   end
 
   def data
-    '{"user_id":"dab48d26-e4f8-41fc-a9a8-59657e590716","email":"encrypted","first_name":"encrypted"}' # rubocop:disable Metrics/LineLength
+    JSON.generate(
+      user_id: 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+      first_name: 'encrypted',
+      last_name: 'encrypted',
+      profession: 'Jedi',
+      encrypted: 'darthvader'
+    )
   end
 
   private

--- a/spec/support/dummy_repository.rb
+++ b/spec/support/dummy_repository.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DummyRepository
+  class Key
+    attr_accessor :iv, :cipher, :id
+    def initialize(id:, **)
+      @id = id
+    end
+  end
+
+  def find(user_id)
+    Key.new(id: user_id)
+  end
+
+  def encrypt(*)
+    'darthvader'
+  end
+
+  def decrypt(*)
+    JSON.gnereate(first_name: 'Anakin', last_name: 'Skylwalker')
+  end
+end

--- a/spec/support/encrypted_event.rb
+++ b/spec/support/encrypted_event.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class EncryptedEvent < EventStoreClient::DeserializedEvent
+  def schema
+    Dry::Schema.Params do
+      required(:user_id).value(:string)
+      required(:first_name).value(:string)
+      required(:last_name).value(:string)
+      required(:profession).value(:string)
+    end
+  end
+
+  def self.encryption_schema
+    {
+      key: ->(data) { data[:user_id] },
+      attributes: %i[first_name last_name]
+    }
+  end
+end

--- a/spec/support/serialized_encrypted_event.rb
+++ b/spec/support/serialized_encrypted_event.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class SerializedEncryptedEvent
+  attr_reader :type
+
+  def metadata
+    '{"created_at":"2019-12-05 19:37:38 +0100"}'
+  end
+
+  def data
+    JSON.generate(
+      user_id: 'dab48d26-e4f8-41fc-a9a8-59657e590716',
+      first_name: 'encrypted',
+      last_name: 'encrypted',
+      profession: 'Jedi',
+      encrypted: 'darthvader'
+    )
+  end
+
+  private
+
+  def initialize(type:)
+    @type = type
+  end
+end


### PR DESCRIPTION
To match GDPR expectations, best is to allow to encrypt events used in the system.

I managed to not require dependency with our private `encryptor_client` gem by injecting the dependency from the outside.

### Dev notes

Easiest for review is to start from README changes and SPEC files.
