### PR TITLE
Pro 2519 pagination for reading events

### DIFF
--- a/lib/event_store_client/client.rb
+++ b/lib/event_store_client/client.rb
@@ -10,8 +10,8 @@ module EventStoreClient
       connection.publish(stream: stream, events: events, expected_version: expected_version)
     end
 
-    def read(stream, direction: 'forward', start: 0, count: 20, all: false)
-      connection.read(stream, direction: direction, start: start, count: count, all: all)
+    def read(stream, direction: 'forward', start: 0, all: false)
+      connection.read(stream, direction: direction, start: start, all: all)
     end
 
     def subscribe(subscriber, to: [], polling: true)

--- a/lib/event_store_client/client.rb
+++ b/lib/event_store_client/client.rb
@@ -10,8 +10,8 @@ module EventStoreClient
       connection.publish(stream: stream, events: events, expected_version: expected_version)
     end
 
-    def read(stream, direction: 'forward')
-      connection.read(stream, direction: direction)
+    def read(stream, direction: 'forward', start: 0, count: 20, all: false)
+      connection.read(stream, direction: direction, start: start, count: count, all: all)
     end
 
     def subscribe(subscriber, to: [], polling: true)

--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -82,8 +82,7 @@ module EventStoreClient
       return [] if response.body.nil? || response.body.empty?
       JSON.parse(response.body)['entries'].map do |entry|
         deserialize_event(entry)
-      end
-      response.reverse
+      end.reverse
     end
 
     def read_all_from_stream(stream, resolve_links:)

--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -112,8 +112,7 @@ module EventStoreClient
         title: entry['title'],
         type: entry['eventType'],
         data: entry['data'],
-        metadata: entry['metaData'],
-        number: entry['eventNumber'].to_s
+        metadata: entry['metaData']
       )
       mapper.deserialize(event)
     end

--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -11,13 +11,10 @@ module EventStoreClient
     end
 
     def read(stream, direction:, start:, count:, all:, resolve_links: true)
-      if all
-        read_all_from_stream(stream, resolve_links: resolve_links)
-      else
-        read_from_stream(
-          stream, direction: direction, start: start, count: count, resolve_links: resolve_links
-        )
-      end
+      return read_all_from_stream(stream, resolve_links: resolve_links) if all
+      read_from_stream(
+        stream, direction: direction, start: start, count: count, resolve_links: resolve_links
+      )
     end
 
     def delete_stream(stream); end

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -24,10 +24,15 @@ module EventStoreClient
 
         def read(stream_name, direction: 'forward', start: 0, count: per_page, resolve_links: true)
           headers = {
-            'ES-ResolveLinkTos' => resolve_links.to_s
+            'ES-ResolveLinkTos' => resolve_links.to_s,
+            'Accept' => 'application/vnd.eventstore.atom+json'
           }
 
-          make_request(:get, "/streams/#{stream_name}/#{start}/#{direction}/#{count}", headers: headers)
+          make_request(
+            :get,
+            "/streams/#{stream_name}/#{start}/#{direction}/#{count}",
+            headers: headers
+          )
         end
 
         def subscribe_to_stream(

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -21,7 +21,6 @@ module EventStoreClient
 
       def read(stream_name, direction: 'forward', start: 0, count: per_page, resolve_links: nil)
         read_stream_forward(stream_name, start: start, count: count) if direction == 'forward'
-
         read_stream_backward(stream_name, start: start, count: count)
       end
 
@@ -46,9 +45,9 @@ module EventStoreClient
       def read_stream_backward(stream_name, start: 0, count: per_page)
         return [] unless event_store.key?(stream_name)
 
-        start = start.zero? ? event_store[stream_name].length - 1 : start
+        start = start == 'head' ? event_store[stream_name].length - 1 : start
         last_index = start - count
-        entries = event_store[stream_name].select do |event|
+        entries = event_store[stream_name].reverse.select do |event|
           event['positionEventNumber'] > last_index &&
             event['positionEventNumber'] <= start
         end

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -3,6 +3,8 @@
 module EventStoreClient
   module StoreAdapter
     class InMemory
+      Response = Struct.new(:body)
+
       attr_reader :event_store
 
       def append_to_stream(stream_name, events, expected_version: nil) # rubocop:disable Lint/UnusedMethodArgument,Metrics/LineLength
@@ -26,7 +28,8 @@ module EventStoreClient
           else
             read_stream_backward(stream_name, start: start, count: count)
           end
-        OpenStruct.new(body: response.to_json)
+
+        Response.new(response.to_json)
       end
 
       def delete_stream(stream_name, hard_delete: false) # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -21,12 +21,12 @@ module EventStoreClient
         end
       end
 
-      def read(stream_name, direction: 'forward', start: 0, count: per_page, resolve_links: nil)
+      def read(stream_name, direction: 'forward', start: 0, resolve_links: nil)
         response =
           if direction == 'forward'
-            read_stream_forward(stream_name, start: start, count: count)
+            read_stream_forward(stream_name, start: start)
           else
-            read_stream_backward(stream_name, start: start, count: count)
+            read_stream_backward(stream_name, start: start)
           end
 
         Response.new(response.to_json)
@@ -50,32 +50,32 @@ module EventStoreClient
         @event_store = {}
       end
 
-      def read_stream_backward(stream_name, start: 0, count: per_page)
+      def read_stream_backward(stream_name, start: 0)
         return [] unless event_store.key?(stream_name)
 
         start = start == 'head' ? event_store[stream_name].length - 1 : start
-        last_index = start - count
+        last_index = start - per_page
         entries = event_store[stream_name].select do |event|
           event['positionEventNumber'] > last_index &&
             event['positionEventNumber'] <= start
         end
         {
           'entries' => entries,
-          'links' => links(stream_name, last_index, 'next', entries, count)
+          'links' => links(stream_name, last_index, 'next', entries, per_page)
         }
       end
 
-      def read_stream_forward(stream_name, start: 0, count: per_page)
+      def read_stream_forward(stream_name, start: 0)
         return [] unless event_store.key?(stream_name)
 
-        last_index = start + count
+        last_index = start + per_page
         entries = event_store[stream_name].select do |event|
           event['positionEventNumber'] < last_index &&
             event['positionEventNumber'] >= start
         end
         {
           'entries' => entries,
-          'links' => links(stream_name, last_index, 'previous', entries, count)
+          'links' => links(stream_name, last_index, 'previous', entries, per_page)
         }
       end
 

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -3,7 +3,11 @@
 module EventStoreClient
   module StoreAdapter
     class InMemory
-      Response = Struct.new(:body)
+      Response = Struct.new(:body, :status) do
+        def success?
+          status == 200
+        end
+      end
 
       attr_reader :event_store
 
@@ -29,7 +33,7 @@ module EventStoreClient
             read_stream_backward(stream_name, start: start)
           end
 
-        Response.new(response.to_json)
+        Response.new(response.to_json, 200)
       end
 
       def delete_stream(stream_name, hard_delete: false) # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -13,7 +13,7 @@ module EventStoreClient
             'eventId' => event.id,
             'data' => event.data,
             'eventType' => event.type,
-            'metadata' => event.metadata,
+            'metaData' => event.metadata,
             'positionEventNumber' => event_store[stream_name].length
           )
         end

--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -20,8 +20,13 @@ module EventStoreClient
       end
 
       def read(stream_name, direction: 'forward', start: 0, count: per_page, resolve_links: nil)
-        read_stream_forward(stream_name, start: start, count: count) if direction == 'forward'
-        read_stream_backward(stream_name, start: start, count: count)
+        response =
+          if direction == 'forward'
+            read_stream_forward(stream_name, start: start, count: count)
+          else
+            read_stream_backward(stream_name, start: start, count: count)
+          end
+        OpenStruct.new(body: response.to_json)
       end
 
       def delete_stream(stream_name, hard_delete: false) # rubocop:disable Lint/UnusedMethodArgument
@@ -47,7 +52,7 @@ module EventStoreClient
 
         start = start == 'head' ? event_store[stream_name].length - 1 : start
         last_index = start - count
-        entries = event_store[stream_name].reverse.select do |event|
+        entries = event_store[stream_name].select do |event|
           event['positionEventNumber'] > last_index &&
             event['positionEventNumber'] <= start
         end
@@ -61,7 +66,7 @@ module EventStoreClient
         return [] unless event_store.key?(stream_name)
 
         last_index = start + count
-        entries = event_store[stream_name].reverse.select do |event|
+        entries = event_store[stream_name].select do |event|
           event['positionEventNumber'] < last_index &&
             event['positionEventNumber'] >= start
         end

--- a/spec/event_store_client/client_spec.rb
+++ b/spec/event_store_client/client_spec.rb
@@ -38,16 +38,17 @@ module EventStoreClient
       end
 
       context 'backward' do
-        it 'reads a latest event from a stream' do
-          events = client.read('stream', direction: 'backard', start: 'head', count: 1)
-          expect(events.count).to eq(1)
-          expect(events.first.type).to eq('SomethingElseHappened')
+        it 'reads events from a stream' do
+          events = client.read('stream', direction: 'backard', start: 'head')
+          expect(events.count).to eq(2)
+          expect(events.map { |event| event.type }).
+            to eq(['SomethingHappened', 'SomethingElseHappened'])
         end
       end
 
       context 'all' do
         it 'reads all events from a stream' do
-          events = client.read('stream', count: 1, all: true)
+          events = client.read('stream', all: true)
           expect(events.count).to eq(2)
           expect(events.map { |event| event.type }).
             to eq(['SomethingHappened', 'SomethingElseHappened'])

--- a/spec/event_store_client/client_spec.rb
+++ b/spec/event_store_client/client_spec.rb
@@ -29,20 +29,28 @@ module EventStoreClient
       end
 
       context 'forward' do
-        it 'reads events from the store', pending: true do
-          pending('missing implementation of EventStoreClient::StoreAdapter::InMemory#read')
-          events = client.read('stream', direction: 'forward')
-          expect(events[0].type).to eq('SomethingHappened')
-          expect(events[1].type).to eq('SomethingElseHappened')
+        it 'reads events from a stream' do
+          events = client.read('stream')
+          expect(events.count).to eq(2)
+          expect(events.map { |event| event.type }).
+            to eq(['SomethingHappened', 'SomethingElseHappened'])
         end
       end
 
       context 'backward' do
-        it 'reads events from the store', pending: true do
-          pending('missing implementation of EventStoreClient::StoreAdapter::InMemory#read')
-          events = client.read('stream', direction: 'backard')
-          expect(events[0].type).to eq('SomethingElseHappened')
-          expect(events[1].type).to eq('SomethingHappened')
+        it 'reads a latest event from a stream' do
+          events = client.read('stream', direction: 'backard', start: 'head', count: 1)
+          expect(events.count).to eq(1)
+          expect(events.first.type).to eq('SomethingElseHappened')
+        end
+      end
+
+      context 'all' do
+        it 'reads all events from a stream' do
+          events = client.read('stream', count: 1, all: true)
+          expect(events.count).to eq(2)
+          expect(events.map { |event| event.type }).
+            to eq(['SomethingHappened', 'SomethingElseHappened'])
         end
       end
     end

--- a/spec/event_store_client/connection_spec.rb
+++ b/spec/event_store_client/connection_spec.rb
@@ -54,13 +54,14 @@ module EventStoreClient
           'stream', [something_happened_1, something_happened_2, something_happened_3]
         )
         allow_any_instance_of(described_class).to receive(:client).and_return(in_memory)
+        allow_any_instance_of(described_class).to receive(:per_page).and_return(2)
       end
 
       context 'forward' do
         context 'when a count is equal to 2' do
           it 'returns two first events in order from the oldest to the latest' do
             events =
-              connection.read('stream', direction: 'forward', count: 2, start: 0, all: false)
+              connection.read('stream', direction: 'forward', start: 0, all: false)
             expect(events.count).to eq(2)
             expect(events.map { |event| event.type }).
               to eq(['SomethingHappened1', 'SomethingHappened2'])
@@ -72,7 +73,7 @@ module EventStoreClient
         context 'when a count is eqaul to 2 and start is equal to head' do
           it 'returns two last events in order from the oldest to the latest' do
             events =
-              connection.read('stream', direction: 'backward', count: 2, start: 'head', all: false)
+              connection.read('stream', direction: 'backward', start: 'head', all: false)
             expect(events.count).to eq(2)
             expect(events.map { |event| event.type }).
               to eq(['SomethingHappened2', 'SomethingHappened3'])
@@ -83,7 +84,7 @@ module EventStoreClient
       context 'all' do
         it 'returns all evens in order from the oldest to the latest' do
           events =
-            connection.read('stream', direction: 'forward', count: 2, start: 0, all: true)
+            connection.read('stream', direction: 'forward', start: 0, all: true)
           expect(events.count).to eq(3)
           expect(events.map { |event| event.type }).
             to eq(['SomethingHappened1', 'SomethingHappened2', 'SomethingHappened3'])

--- a/spec/event_store_client/connection_spec.rb
+++ b/spec/event_store_client/connection_spec.rb
@@ -21,7 +21,75 @@ module EventStoreClient
       end
     end
 
-    describe '#read' do; end
+    describe '#read' do
+      let(:in_memory) do
+        EventStoreClient::StoreAdapter::InMemory.new(
+          host: 'https://example.com', port: 8080, per_page: 2
+        )
+      end
+      let(:something_happened_1) do
+        Event.new(
+          type: 'SomethingHappened1',
+          data: JSON.generate(foo: 'bar'),
+          metadata: JSON.generate(bar: 'foo')
+        )
+      end
+      let(:something_happened_2) do
+        Event.new(
+          type: 'SomethingHappened2',
+          data: JSON.generate(foo: 'bar'),
+          metadata: JSON.generate(bar: 'foo')
+        )
+      end
+      let(:something_happened_3) do
+        Event.new(
+          type: 'SomethingHappened3',
+          data: JSON.generate(foo: 'bar'),
+          metadata: JSON.generate(bar: 'foo')
+        )
+      end
+
+      before do
+        in_memory.append_to_stream(
+          'stream', [something_happened_1, something_happened_2, something_happened_3]
+        )
+        allow_any_instance_of(described_class).to receive(:client).and_return(in_memory)
+      end
+
+      context 'forward' do
+        context 'when a count is equal to 2' do
+          it 'returns two first events in order from the oldest to the latest' do
+            events =
+              connection.read('stream', direction: 'forward', count: 2, start: 0, all: false)
+            expect(events.count).to eq(2)
+            expect(events.map { |event| event.type }).
+              to eq(['SomethingHappened1', 'SomethingHappened2'])
+          end
+        end
+      end
+
+      context 'backward' do
+        context 'when a count is eqaul to 2 and start is equal to head' do
+          it 'returns two last events in order from the oldest to the latest' do
+            events =
+              connection.read('stream', direction: 'backward', count: 2, start: 'head', all: false)
+            expect(events.count).to eq(2)
+            expect(events.map { |event| event.type }).
+              to eq(['SomethingHappened2', 'SomethingHappened3'])
+          end
+        end
+      end
+
+      context 'all' do
+        it 'returns all evens in order from the oldest to the latest' do
+          events =
+            connection.read('stream', direction: 'forward', count: 2, start: 0, all: true)
+          expect(events.count).to eq(3)
+          expect(events.map { |event| event.type }).
+            to eq(['SomethingHappened1', 'SomethingHappened2', 'SomethingHappened3'])
+        end
+      end
+    end
 
     describe '#subscribe' do
       it 'invokes the subscribe_to_stream method' do

--- a/spec/event_store_client/store_adapter/in_memory_spec.rb
+++ b/spec/event_store_client/store_adapter/in_memory_spec.rb
@@ -18,7 +18,7 @@ module EventStoreClient
             'positionEventNumber' => 0
           )
         )
-        metadata = JSON.parse(subject.event_store['sample_stream'].first['metadata'])
+        metadata = JSON.parse(subject.event_store['sample_stream'].first['metaData'])
         expect(metadata['created_at']).not_to be_empty
         expect(metadata['bar']).to eq('foo')
       end

--- a/spec/event_store_client/store_adapter/in_memory_spec.rb
+++ b/spec/event_store_client/store_adapter/in_memory_spec.rb
@@ -59,10 +59,29 @@ module EventStoreClient
       end
 
       it 'returns events in proper order' do
-        events = subject.send(:read_stream_backward, 'sample_stream', start: 0)['entries']
+        events = subject.send(:read_stream_backward, 'sample_stream', start: 10)['entries']
         expect(
           events.map { |event| event['positionEventNumber'] }
-        ).to eq([1, 0])
+        ).to eq([0, 1])
+      end
+
+      context 'when a start is equal to 0' do
+        it 'returns the oldest event' do
+          events = subject.send(:read_stream_backward, 'sample_stream', start: 0)['entries']
+          expect(events.count).to eq(1)
+          expect(
+            events.map { |event| event['positionEventNumber'] }
+          ).to eq([0])
+        end
+      end
+
+      context 'when a start is equal to head' do
+        it 'returns events' do
+          events = subject.send(:read_stream_backward, 'sample_stream', start: 'head')['entries']
+          expect(
+            events.map { |event| event['positionEventNumber'] }
+          ).to eq([0, 1])
+        end
       end
     end
 
@@ -83,6 +102,16 @@ module EventStoreClient
         expect(
           events.map { |event| event['positionEventNumber'] }
         ).to eq([0, 1])
+      end
+
+      context 'when a start is equal to a last event position' do
+        it 'returns the newest event' do
+          events = subject.send(:read_stream_forward, 'sample_stream', start: 1)['entries']
+          expect(events.count).to eq(1)
+          expect(
+            events.map { |event| event['positionEventNumber'] }
+          ).to eq([1])
+        end
       end
     end
 

--- a/spec/event_store_client/store_adapter/in_memory_spec.rb
+++ b/spec/event_store_client/store_adapter/in_memory_spec.rb
@@ -62,7 +62,7 @@ module EventStoreClient
         events = subject.send(:read_stream_backward, 'sample_stream', start: 10)['entries']
         expect(
           events.map { |event| event['positionEventNumber'] }
-        ).to eq([0, 1])
+        ).to eq([1, 0])
       end
 
       context 'when a start is equal to 0' do
@@ -80,7 +80,7 @@ module EventStoreClient
           events = subject.send(:read_stream_backward, 'sample_stream', start: 'head')['entries']
           expect(
             events.map { |event| event['positionEventNumber'] }
-          ).to eq([0, 1])
+          ).to eq([1, 0])
         end
       end
     end
@@ -101,7 +101,7 @@ module EventStoreClient
         events = subject.send(:read_stream_forward, 'sample_stream', start: 0)['entries']
         expect(
           events.map { |event| event['positionEventNumber'] }
-        ).to eq([0, 1])
+        ).to eq([1, 0])
       end
 
       context 'when a start is equal to a last event position' do


### PR DESCRIPTION
### **Feat:**
- Added pagination support.
- Fixed `backward` reading.
- Changed the order of returned events. Now events are ordered from the oldest to the latest.
- Added a bunch of tests (removed pendings).
- Customized the `InMemory` adapter to the Client that works with real Event Store. Event Store returns events in order from the oldest to the latest. It's why I removed `reverse` from the InMemory adapter.