### PR TITLE
Pro 2619 add tests to in memory

### DIFF
--- a/lib/event_store_client/store_adapter/in_memory.rb
+++ b/lib/event_store_client/store_adapter/in_memory.rb
@@ -36,12 +36,24 @@ module EventStoreClient
         Response.new(response.to_json, 200)
       end
 
+      def subscribe_to_stream
+        # TODO: implement method body
+      end
+
+      def consume_feed
+        # TODO: implement method body
+      end
+
       def delete_stream(stream_name, hard_delete: false) # rubocop:disable Lint/UnusedMethodArgument
         event_store.delete(stream_name)
       end
 
       def link_to(stream_name, events)
         append_to_stream(stream_name, events)
+      end
+
+      def ack
+        # TODO: implement method body
       end
 
       private

--- a/spec/event_store_client/store_adapter/in_memory_spec.rb
+++ b/spec/event_store_client/store_adapter/in_memory_spec.rb
@@ -158,5 +158,10 @@ module EventStoreClient
         metadata: { bar: 'foo' }.to_json
       )
     end
+
+    it 'implmenetes the same methods as the Client' do
+      client_methods = EventStoreClient::StoreAdapter::Api::Client.instance_methods(false).sort
+      expect(subject.class.instance_methods(false).sort).to eq(client_methods)
+    end
   end
 end

--- a/spec/event_store_client/store_adapter/in_memory_spec.rb
+++ b/spec/event_store_client/store_adapter/in_memory_spec.rb
@@ -161,7 +161,7 @@ module EventStoreClient
 
     it 'implmenetes the same methods as the Client' do
       client_methods = EventStoreClient::StoreAdapter::Api::Client.instance_methods(false).sort
-      expect(subject.class.instance_methods(false).sort).to eq(client_methods)
+      expect(described_class.instance_methods(false).sort - [:event_store]).to eq(client_methods)
     end
   end
 end


### PR DESCRIPTION
### **Feat:**
- Added the test that verifies whether `InMemory` includes the same methods as `Client`.
- Added missing methods to `InMemory` with `TODO` body.

### **Refer to**
- [PRO-2619](https://yousty.atlassian.net/browse/PRO-2619)

### **Notes**
- In the test, I added removing the `event_store` from the array with methods. The `InMemory` adapter has the public `event_store` reader that is using in tests. It was the easiest solution. I also tried to make it private, then mock the `event_store` method, but after mocking the `instance_methods` returns `event_store` as a public method.