### PR TITLE
Add support for publishing events with wrong expected version PRO-2646

### DIFF
--- a/lib/event_store_client/client.rb
+++ b/lib/event_store_client/client.rb
@@ -5,9 +5,12 @@ require 'dry-struct'
 module EventStoreClient
   class Client
     NoCallMethodOnSubscriber = Class.new(StandardError)
+    WrongExpectedEventVersion = Class.new(StandardError)
 
     def publish(stream:, events:, expected_version: nil)
       connection.publish(stream: stream, events: events, expected_version: expected_version)
+    rescue EventStoreClient::StoreAdapter::Api::Client::WrongExpectedEventVersion => e
+      raise WrongExpectedEventVersion.new(e.message)
     end
 
     def read(stream, direction: 'forward', start: 0, all: false)

--- a/lib/event_store_client/client.rb
+++ b/lib/event_store_client/client.rb
@@ -9,7 +9,7 @@ module EventStoreClient
 
     def publish(stream:, events:, expected_version: nil)
       connection.publish(stream: stream, events: events, expected_version: expected_version)
-    rescue EventStoreClient::StoreAdapter::Api::Client::WrongExpectedEventVersion => e
+    rescue StoreAdapter::Api::Client::WrongExpectedEventVersion => e
       raise WrongExpectedEventVersion.new(e.message)
     end
 
@@ -64,12 +64,15 @@ module EventStoreClient
       nil
     end
 
-    def link_to(stream:, events:)
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def link_to(stream:, events:, expected_version: nil)
       raise ArgumentError if !stream || stream == ''
       raise ArgumentError if events.nil? || (events.is_a?(Array) && events.empty?)
-
-      connection.link_to(stream, events)
+      connection.link_to(stream, events, expected_version: expected_version)
+    rescue StoreAdapter::Api::Client::WrongExpectedEventVersion => e
+      raise WrongExpectedEventVersion.new(e.message)
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     attr_accessor :connection, :service_name
 

--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -43,8 +43,8 @@ module EventStoreClient
       events
     end
 
-    def link_to(stream, events)
-      client.link_to(stream, events)
+    def link_to(stream, events, expected_version: nil)
+      client.link_to(stream, events, expected_version: expected_version)
 
       true
     end

--- a/lib/event_store_client/event.rb
+++ b/lib/event_store_client/event.rb
@@ -6,8 +6,7 @@ require 'json'
 
 module EventStoreClient
   class Event < Dry::Struct
-    attr_reader :id
-
+    attribute :id, Types::Strict::String.optional.default(nil)
     attribute :type, Types::Strict::String
     attribute :title, Types::Strict::String.optional.default(nil)
     attribute :data, Types::Strict::String.default('{}')
@@ -16,7 +15,7 @@ module EventStoreClient
     private
 
     def initialize(**args)
-      @id = SecureRandom.uuid
+      id = args[:id] || SecureRandom.uuid
       hash_meta = JSON.parse(args[:metadata] || '{}')
       hash_meta['created_at'] ||= Time.now
       args[:metadata] = JSON.generate(hash_meta)

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -9,7 +9,7 @@ module EventStoreClient
         def append_to_stream(stream_name, events, expected_version: nil)
           headers = {
             'ES-ExpectedVersion' => expected_version&.to_s
-          }.reject { |_key, val| val.nil? }
+          }.reject { |_key, val| val.nil? || val.empty? }
 
           data = build_events_data(events)
           response = make_request(:post, "/streams/#{stream_name}", body: data, headers: headers)
@@ -76,7 +76,7 @@ module EventStoreClient
           data = build_linkig_data(events)
           headers = {
             'ES-ExpectedVersion' => expected_version&.to_s
-          }.reject { |_key, val| val.nil? }
+          }.reject { |_key, val| val.nil? || val.empty? }
 
           response = make_request(
             :post,

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -8,8 +8,8 @@ module EventStoreClient
 
         def append_to_stream(stream_name, events, expected_version: nil)
           headers = {
-            'ES-ExpectedVersion' => expected_version.to_s
-          }.reject { |_key, val| val.empty? }
+            'ES-ExpectedVersion' => expected_version&.to_s
+          }.reject { |_key, val| val.nil? }
 
           data = build_events_data(events)
 

--- a/spec/event_store_client/client_spec.rb
+++ b/spec/event_store_client/client_spec.rb
@@ -66,7 +66,8 @@ module EventStoreClient
       before do
         allow_any_instance_of(Connection).to receive(:link_to).with(
           stream_name,
-          events
+          events,
+          expected_version: nil
         ).and_return(events)
       end
 
@@ -78,7 +79,11 @@ module EventStoreClient
 
       shared_examples 'correct linking events' do
         it 'invokes link event for the store' do
-          expect_any_instance_of(Connection).to receive(:link_to).with(stream_name, events)
+          expect_any_instance_of(Connection).to receive(:link_to).with(
+            stream_name,
+            events,
+            expected_version: nil
+          )
 
           subject.call
         end


### PR DESCRIPTION
### Overview
In order to communicate that the client is trying to publish events with the wrong expected version, I added raising the `WrongExpectedEventVersion` exception. It concerns `link_to` method as well.
- Fixed missing `id` bug of Event.
- Fixed header of `append_to_stream` method.

### Refer to:
- Jira ticket: [PRO-2646](https://yousty.atlassian.net/browse/PRO-2646)

### Dev notes
[Event Store Documentation: Expected Version](https://eventstore.com/docs/http-api/optional-http-headers/expected-version/index.html?tabs=tabid-1%2Ctabid-3%2Ctabid-5)
