### PR TITLE
Fix consume_feed to not skip event title

### DIFF
--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -33,6 +33,7 @@ module EventStoreClient
       events = body['entries'].map do |entry|
         event = EventStoreClient::Event.new(
           id: entry['eventId'],
+          title: entry['title'],
           type: entry['eventType'],
           data: entry['data'] || '{}',
           metadata: entry['isMetaData'] ? entry['metaData'] : '{}'


### PR DESCRIPTION
### **Overview**
- Added missing `title` attribute to the event initialization.