### PR TITLE
Fix reading events

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,16 @@ client.publish(stream: 'newstream', events: [event])
 events = client.read('newstream')
 ```
 
-**Changing reading direction
+**Changing reading direction**
 
 ```ruby
 events = client.read('newstream', direction: 'backward') #default 'forward'
+```
+
+**Reading all events from a stream**
+
+```ruby
+events = client.read('newstream', all: true) #default 'false'
 ```
 
 ### Subscribing to events

--- a/lib/event_store_client/connection.rb
+++ b/lib/event_store_client/connection.rb
@@ -92,7 +92,7 @@ module EventStoreClient
         begin
           response =
             client.read(stream, start: start, direction: 'forward', resolve_links: resolve_links)
-          failed_requests_count += 1 && next unless response.success?
+          failed_requests_count += 1 && next unless response.success? || response.status == 404
         rescue Faraday::ConnectionFailed
           failed_requests_count += 1
           next


### PR DESCRIPTION
### **Overview**
- `EventsStore` returns 404 response when a client tries to read from a not existing stream. I added handling this case to the `read_all_from_stream` method in order to treat 404 as a correct response but without contains events.
- Added `reading all events` to the readme.