### PR TITLE
Add projections merging multiple streams together to keep order of events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    event_store_client (0.1.15)
+    event_store_client (0.1.16)
       dry-schema (~> 1.4.1)
       dry-struct (~> 1.1.1)
       faraday (~> 0.17.0)

--- a/lib/event_store_client/broker.rb
+++ b/lib/event_store_client/broker.rb
@@ -6,11 +6,7 @@ module EventStoreClient
       subscriptions.each do |subscription|
         new_events = connection.consume_feed(subscription.stream, subscription.name)
         next if new_events.none?
-        new_events.each do |event|
-          subscription.subscribers.each do |subscriber|
-            subscriber.call(event)
-          end
-        end
+        new_events.each { |event| subscription.subscriber.call(event) }
       end
     end
 

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -61,7 +61,7 @@ module EventStoreClient
               extraStatistics: stats,
               startFrom: start_from,
               maxRetryCount: retries,
-              resolveLinkTos: true
+              resolveLinktos: true
             },
             headers: {
               'Content-Type' => 'application/json'

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -41,6 +41,11 @@ module EventStoreClient
         def join_streams(name, streams)
           data = <<~STRING
             fromStreams(#{streams})
+            .when({
+              $any: function(s,e) {
+                linkTo("#{name}", e)
+              }
+            })
           STRING
 
           make_request(

--- a/lib/event_store_client/store_adapter/api/client.rb
+++ b/lib/event_store_client/store_adapter/api/client.rb
@@ -38,6 +38,19 @@ module EventStoreClient
           )
         end
 
+        def join_streams(name, streams)
+          data = <<~STRING
+            fromStreams(#{streams})
+          STRING
+
+          make_request(
+            :post,
+            "/projections/continuous?name=#{name}&type=js&enabled=true&emit=true%26trackemittedstreams=true", # rubocop:disable Metrics/LineLength
+            body: data,
+            headers: {}
+          )
+        end
+
         def subscribe_to_stream(
           stream_name, subscription_name, stats: true, start_from: 0, retries: 5
         )
@@ -60,11 +73,14 @@ module EventStoreClient
           stream_name,
           subscription_name,
           count: 1,
-          long_poll: 0
+          long_poll: 0,
+          resolve_links: true
         )
           headers = long_poll.positive? ? { 'ES-LongPoll' => long_poll.to_s } : {}
           headers['Content-Type'] = 'application/vnd.eventstore.competingatom+json'
           headers['Accept'] = 'application/vnd.eventstore.competingatom+json'
+          headers['ES-ResolveLinkTos'] = resolve_links.to_s
+
           make_request(
             :get,
             "/subscriptions/#{stream_name}/#{subscription_name}/#{count}",
@@ -126,7 +142,7 @@ module EventStoreClient
           method = RequestMethod.new(method_name)
           connection.send(method.to_s, path) do |req|
             req.headers = req.headers.merge(headers)
-            req.body = body.to_json
+            req.body = body.is_a?(String) ? body : body.to_json
             req.params['embed'] = 'body' if method == :get
           end
         end

--- a/lib/event_store_client/subscription.rb
+++ b/lib/event_store_client/subscription.rb
@@ -2,15 +2,21 @@
 
 module EventStoreClient
   class Subscription
-    attr_accessor :subscribers
-    attr_reader :stream, :name
+    attr_reader :stream, :subscriber, :name, :observed_streams
 
     private
 
-    def initialize(type:, name:)
-      @name = name
-      @subscribers = []
-      @stream = "$et-#{type}"
+    def initialize(subscriber, service:, event_types:)
+      subscriber_class =
+        if subscriber.class.name == 'Class'
+          subscriber.name
+        else
+          subscriber.class.name
+        end
+      @name = "#{service}-#{subscriber_class}"
+      @subscriber = subscriber
+      @stream = "$projections-#{name}-order"
+      @observed_streams = event_types.reduce([]) { |r, type| r << "$et-#{type}" }
     end
   end
 end

--- a/lib/event_store_client/subscription.rb
+++ b/lib/event_store_client/subscription.rb
@@ -15,7 +15,7 @@ module EventStoreClient
         end
       @name = "#{service}-#{subscriber_class}"
       @subscriber = subscriber
-      @stream = "$projections-#{name}-order"
+      @stream = name
       @observed_streams = event_types.reduce([]) { |r, type| r << "$et-#{type}" }
     end
   end

--- a/lib/event_store_client/version.rb
+++ b/lib/event_store_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module EventStoreClient
-  VERSION = '0.1.15'
+  VERSION = '0.1.16'
 end


### PR DESCRIPTION
### Overview

I've changed the subscription mechanism. Now subscription has one subscriber, and one stream to listen, built from the array of event types to observe.

**Issue:** 

Our first implementation assumed that subscriber subscribes to several streams - each stream for each type of event to observe...

But that returned with events arrived in the wrong order because of latency and processing time.

To resolve it, each subscriber needs to have its own projection to subscribe, which will keep order of events published.

- [x] Create projections for every subscription
- [x] Design mechanism to keep-up with events by processing all of them (allow to temporary disable event handlers, like notification systems.)
- [x] What happens when we'll re-deploy change (and we'll try to create new subscription again?)


**Next steps...**

We can build subscription names based on events they listen to...
- [ ] Design solution to change subscription list - what if we'll want to remove/add events to listen?
- [ ] Design solution to clear old, unused projections/subscriptions.

