### PR TITLE
Fix Broker#call method

### DIFF
--- a/lib/event_store_client/broker.rb
+++ b/lib/event_store_client/broker.rb
@@ -4,7 +4,7 @@ module EventStoreClient
   class Broker
     def call(subscriptions)
       subscriptions.each do |subscription|
-        new_events = connection.consume_feed(subscription.stream, subscription.name)
+        new_events = connection.consume_feed(subscription.stream, subscription.name) || []
         next if new_events.none?
         new_events.each { |event| subscription.subscriber.call(event) }
       end


### PR DESCRIPTION
### **Overview**
- We noticed that the `new_events` variable can be nil, so I added an empty array in order to the `none?` method doesn't be called on nil.